### PR TITLE
FIN-3180: Make django-rest-hooks compatible with our Django version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,12 @@ target/
 
 #Test Coverage
 tests/reports/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/devrequirements.txt
+++ b/devrequirements.txt
@@ -1,2 +1,3 @@
-requests==1.2.3
-mock==1.0.1
+requests>=2.28.1
+mock>=4.0.3
+django-contrib-comments>=2.2.0

--- a/devrequirements_1.10.txt
+++ b/devrequirements_1.10.txt
@@ -1,3 +1,0 @@
--r devrequirements.txt
-django-contrib-comments>=1.7.2
-Django>=1.10,<1.11

--- a/devrequirements_1.11.txt
+++ b/devrequirements_1.11.txt
@@ -1,3 +1,0 @@
--r devrequirements.txt
-django-contrib-comments>=1.8.0
-Django>=1.11,<1.12

--- a/devrequirements_1.5.txt
+++ b/devrequirements_1.5.txt
@@ -1,2 +1,0 @@
--r devrequirements.txt
-Django>=1.5,<1.6

--- a/devrequirements_1.8.txt
+++ b/devrequirements_1.8.txt
@@ -1,3 +1,0 @@
--r devrequirements.txt
-django-contrib-comments>=1.6.1,<1.7.0
-Django>=1.8,<1.9

--- a/devrequirements_1.9.txt
+++ b/devrequirements_1.9.txt
@@ -1,3 +1,0 @@
--r devrequirements.txt
-django-contrib-comments>=1.6.2,<1.7.0
-Django>=1.9,<1.10

--- a/devrequirements_2.0.txt
+++ b/devrequirements_2.0.txt
@@ -1,3 +1,0 @@
--r devrequirements.txt
-django-contrib-comments>=1.8.0
-Django>=2.0,<2.1

--- a/devrequirements_4.0.7.txt
+++ b/devrequirements_4.0.7.txt
@@ -1,2 +1,2 @@
 -r devrequirements.txt
-Django>=1.7,<1.8
+Django==4.0.7

--- a/devrequirements_4.0.8.txt
+++ b/devrequirements_4.0.8.txt
@@ -1,2 +1,2 @@
 -r devrequirements.txt
-Django>=1.6,<1.7
+Django==4.0.8

--- a/rest_hooks/__init__.py
+++ b/rest_hooks/__init__.py
@@ -1,1 +1,1 @@
-VERSION = (1, 6, 0)
+VERSION = (1, 6, 1)

--- a/rest_hooks/apps.py
+++ b/rest_hooks/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class RestHooksConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
+    name = 'rest_hooks'

--- a/rest_hooks/models.py
+++ b/rest_hooks/models.py
@@ -73,7 +73,7 @@ class AbstractHook(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
 
-    user = models.ForeignKey(AUTH_USER_MODEL, related_name='%(class)ss', on_delete=models.CASCADE)
+    user = models.ForeignKey(AUTH_USER_MODEL, related_name='hooks', on_delete=models.CASCADE)
     event = models.CharField('Event', max_length=64, db_index=True)
     target = models.URLField('Target URL', max_length=255)
 

--- a/rest_hooks/models.py
+++ b/rest_hooks/models.py
@@ -179,11 +179,7 @@ def get_model_label(instance):
 
 
 @receiver(post_save, dispatch_uid='instance-saved-hook')
-def model_saved(sender, instance,
-                        created,
-                        raw,
-                        using,
-                        **kwargs):
+def model_saved(sender, instance, created, *args, **kwargs):
     """
     Automatically triggers "created" and "updated" actions.
     """
@@ -193,9 +189,7 @@ def model_saved(sender, instance,
 
 
 @receiver(post_delete, dispatch_uid='instance-deleted-hook')
-def model_deleted(sender, instance,
-                          using,
-                          **kwargs):
+def model_deleted(sender, instance, *args, **kwargs):
     """
     Automatically triggers "deleted" actions.
     """

--- a/rest_hooks/signals.py
+++ b/rest_hooks/signals.py
@@ -1,6 +1,6 @@
 from django.dispatch import Signal
 
 
-hook_event = Signal(providing_args=['action', 'instance'])
-raw_hook_event = Signal(providing_args=['event_name', 'payload', 'user'])
-hook_sent_event = Signal(providing_args=['payload', 'instance', 'hook'])
+hook_event = Signal()  # Signal(providing_args=['action', 'instance'])
+raw_hook_event = Signal()  # Signal(providing_args=['event_name', 'payload', 'user'])
+hook_sent_event = Signal()  # Signal(providing_args=['payload', 'instance', 'hook'])

--- a/rest_hooks/utils.py
+++ b/rest_hooks/utils.py
@@ -99,10 +99,10 @@ def find_and_fire_hook(event_name, instance, user_override=None, payload_overrid
             filters['user'] = instance.user
         elif isinstance(instance, User):
             filters['user'] = instance
-        else:
-            raise Exception(
-                '{} has no `user` property. REST Hooks needs this.'.format(repr(instance))
-            )
+        # else:
+        #     raise Exception(
+        #         '{} has no `user` property. REST Hooks needs this.'.format(repr(instance))
+        #     )
     # NOTE: This is probably up for discussion, but I think, in this
     # case, instead of raising an error, we should fire the hook for
     # all users/accounts it is subscribed to. That would be a genuine

--- a/runtests.py
+++ b/runtests.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
-
 import sys
+
 import django
 from django.conf import settings
-
 
 APP_NAME = 'rest_hooks'
 if django.VERSION < (1, 8):
     comments = 'django.contrib.comments'
 else:
     comments = 'django_comments'
+
 
 settings.configure(
     DEBUG=True,
@@ -20,22 +20,36 @@ settings.configure(
     },
     USE_TZ=True,
     ROOT_URLCONF='{0}.tests'.format(APP_NAME),
-    MIDDLEWARE_CLASSES=(
+    MIDDLEWARE=(
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
     ),
     SITE_ID=1,
     HOOK_EVENTS={},
     HOOK_THREADING=False,
     INSTALLED_APPS=(
+        'django.contrib.admin',
         'django.contrib.auth',
         'django.contrib.contenttypes',
         'django.contrib.sessions',
-        'django.contrib.admin',
+        'django.contrib.messages',
+        'django.contrib.staticfiles',
         'django.contrib.sites',
         comments,
         APP_NAME,
     ),
+    TEMPLATES=[{
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    }]
 )
 
 from django.test.utils import get_runner


### PR DESCRIPTION
### Details of changes
- Bump current version to 1.6.1
- Make test works again
- Add venv to .gitignore
- Fix Signal's signature due to deprecation
- Allow non-owner to subscribe to events
- Avoid migration due to django upgrate
- Refactored related_name to avoid migration
- Fix positional/keyword arguments error